### PR TITLE
feat(ui): add double-click to edit instance in grid table

### DIFF
--- a/ui/src/components/grid/GridTable.svelte
+++ b/ui/src/components/grid/GridTable.svelte
@@ -388,7 +388,7 @@
             <!-- Name -->
             <td
               class="px-2 py-1 whitespace-nowrap overflow-hidden select-none"
-              ondblclick={(e) => {
+              ondblclick={e => {
                 e.preventDefault();
                 e.stopPropagation();
                 oncontextaction('edit', instance);


### PR DESCRIPTION
- Added `ondblclick` event handler to trigger the 'edit' context action.
- Added `select-none` class to the cell to prevent native text selection when double-clicking.
- Included event stopper to handle the double-click cleanly.