### PR TITLE
fix(ui): theme icon color not matching hover/active foreground

### DIFF
--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -1412,7 +1412,7 @@
         <div class="relative theme-selector">
           <button
             onclick={toggleThemeDropdown}
-            class="bg-secondary text-secondary-foreground border-2 border-border rounded-lg p-2 flex items-center gap-2 cursor-pointer transition-all hover:bg-primary hover:border-primary hover:text-primary-foreground active:scale-[0.98] shadow-lg"
+            class="group bg-secondary text-secondary-foreground border-2 border-border rounded-lg p-2 flex items-center gap-2 cursor-pointer transition-all hover:bg-primary hover:border-primary hover:text-primary-foreground hover:[&_svg]:!text-current active:scale-[0.98] shadow-lg"
             title="Theme: {getThemeName(getTheme())}"
             aria-label="Toggle theme menu"
           >
@@ -1442,7 +1442,7 @@
                   <button
                     class="w-full flex items-center gap-3 px-3 py-2 border-none cursor-pointer rounded-lg transition-all {getTheme() ===
                     themeOption.id
-                      ? 'bg-primary text-primary-foreground shadow-sm'
+                      ? 'bg-primary text-primary-foreground shadow-sm [&_svg]:!text-current'
                       : 'bg-transparent text-card-foreground hover:bg-secondary/80'}"
                     onclick={() => selectTheme(themeOption.id)}
                   >

--- a/ui/src/components/common/AuthPage.svelte
+++ b/ui/src/components/common/AuthPage.svelte
@@ -86,7 +86,7 @@
     <div class="relative theme-selector">
       <button
         onclick={toggleThemeDropdown}
-        class="bg-secondary text-secondary-foreground border-2 border-border rounded-lg p-2 flex items-center gap-2 cursor-pointer transition-all hover:bg-primary hover:border-primary hover:text-primary-foreground active:scale-[0.98] shadow-lg"
+        class="group bg-secondary text-secondary-foreground border-2 border-border rounded-lg p-2 flex items-center gap-2 cursor-pointer transition-all hover:bg-primary hover:border-primary hover:text-primary-foreground hover:[&_svg]:!text-current active:scale-[0.98] shadow-lg"
         title="Theme: {getThemeName(getTheme())}"
         aria-label="Toggle theme menu"
       >
@@ -115,7 +115,7 @@
               <button
                 class="w-full flex items-center gap-3 px-3 py-2 border-none cursor-pointer rounded-lg transition-all {getTheme() ===
                 themeOption.id
-                  ? 'bg-primary text-primary-foreground shadow-sm'
+                  ? 'bg-primary text-primary-foreground shadow-sm [&_svg]:!text-current'
                   : 'bg-transparent text-card-foreground hover:bg-secondary/80'}"
                 onclick={() => selectTheme(themeOption.id)}
               >

--- a/ui/src/components/common/ThemeIcon.svelte
+++ b/ui/src/components/common/ThemeIcon.svelte
@@ -19,13 +19,13 @@
 {:else if theme === 'system'}
   <Monitor size={18} />
 {:else if theme === 'latte'}
-  <Sun size={18} color={flavorColors.latte} />
+  <Sun size={18} style="color: {flavorColors.latte}" />
 {:else if theme === 'frappe'}
-  <Coffee size={18} color={flavorColors.frappe} />
+  <Coffee size={18} style="color: {flavorColors.frappe}" />
 {:else if theme === 'macchiato'}
-  <Droplet size={18} color={flavorColors.macchiato} />
+  <Droplet size={18} style="color: {flavorColors.macchiato}" />
 {:else if theme === 'mocha'}
-  <Moon size={18} color={flavorColors.mocha} />
+  <Moon size={18} style="color: {flavorColors.mocha}" />
 {:else}
   <Palette size={18} />
 {/if}


### PR DESCRIPTION
Theme icons using Catppuccin flavor colors were not updating their color on hover/active states because the `color` prop set an inline attribute that couldn't be overridden by CSS.

- Switch ThemeIcon from `color` prop to `style="color: ..."`
- Add `hover:[&_svg]:!text-current` to theme toggle button
- Add `[&_svg]:!text-current` to active theme list item
- Apply changes to both App.svelte and AuthPage.svelte

Before:
<img width="272" height="453" alt="image" src="https://github.com/user-attachments/assets/e5b0bb89-56f2-4dce-ba91-9ef7c73f1184" />

After:
<img width="241" height="456" alt="image" src="https://github.com/user-attachments/assets/97f04f8f-d55c-4a25-9a3f-dbe4d6b0ab7a" />
