### PR TITLE
fix: correct sidebar hamburger menu behavior when window resizes

### DIFF
--- a/ui/src/components/layout/Sidebar.svelte
+++ b/ui/src/components/layout/Sidebar.svelte
@@ -45,6 +45,8 @@
   let forceDeleteTarget = $state(null);
   let forceDeleteBusy = $state(false);
   let isGridMode = $derived($viewMode === 'grid');
+  // When opened via mobile overlay (isOpen=true), always treat as expanded
+  let isCompact = $derived(isOpen ? false : isCollapsed);
   let isWatchMode = $derived($viewMode === 'watch');
   let isWatchRuntime = $derived(getRunMode() === 'server' || getRunMode() === 'desktop');
   let watchCount = $state(null);
@@ -392,7 +394,7 @@
     // Mobile: slide in/out
     isOpen ? 'translate-x-0' : '-translate-x-full lg:translate-x-0',
     // Desktop: collapse/expand
-    isCollapsed ? 'w-16' : 'w-64'
+    isCollapsed ? 'w-64 lg:w-16' : 'w-64'
   )}
 >
   <!-- Sidebar Header -->
@@ -420,7 +422,7 @@
     </div>
 
     <!-- View Mode Toggle -->
-    {#if !isCollapsed}
+    {#if !isCompact}
       <div class="space-y-3 mb-4">
         <div class="text-[10px] uppercase tracking-[0.2em] text-muted-foreground px-1">View</div>
         <div class="space-y-1">
@@ -513,7 +515,7 @@
     <!-- Standard Mode Content -->
     {#if !isGridMode && !isWatchMode}
       <!-- Total Stats Summary -->
-      {#if !isCollapsed && (totalStats().uploaded > 0 || totalStats().downloaded > 0)}
+      {#if !isCompact && (totalStats().uploaded > 0 || totalStats().downloaded > 0)}
         <div class="mb-3 p-2 bg-muted/50 rounded-lg text-xs">
           <div class="flex justify-between text-muted-foreground mb-1">
             <span>Total Uploaded</span>
@@ -677,7 +679,7 @@
             </div>
 
             <!-- Ratio Badge (when running or has stats) -->
-            {#if !isCollapsed && instance.stats && instance.stats.ratio > 0}
+            {#if !isCompact && instance.stats && instance.stats.ratio > 0}
               <span
                 class={cn(
                   'flex-shrink-0 text-xs font-bold px-1.5 py-0.5 rounded',
@@ -692,7 +694,7 @@
             {/if}
 
             <!-- Close Button -->
-            {#if !isCollapsed && instance.source !== 'watch_folder'}
+            {#if !isCompact && instance.source !== 'watch_folder'}
               <button
                 class="flex-shrink-0 p-1 rounded hover:bg-destructive/20 group bg-transparent border-0 cursor-pointer"
                 onclick={e => handleRemoveInstance(e, instance.id)}
@@ -705,7 +707,7 @@
                   class="text-muted-foreground group-hover:text-destructive transition-colors"
                 />
               </button>
-            {:else if instance.source === 'watch_folder' && !isCollapsed}
+            {:else if instance.source === 'watch_folder' && !isCompact}
               <!-- Watch folder instance: show folder icon + force delete button -->
               <div class="flex items-center gap-1">
                 <span class="flex-shrink-0 text-muted-foreground" title="From watch folder">
@@ -732,8 +734,8 @@
             {/if}
           </div>
 
-          <!-- Stats Row (when not collapsed and has stats) -->
-          {#if !isCollapsed && instance.stats && instance.isRunning}
+          <!-- Stats Row (when not compact and has stats) -->
+          {#if !isCompact && instance.stats && instance.isRunning}
             <div class="mt-1.5 flex items-center gap-3 text-xs text-muted-foreground pl-5">
               <span class="text-stat-upload" title="Session uploaded">
                 ↑ {formatBytesCompact(instance.stats.session_uploaded)}
@@ -750,7 +752,7 @@
           {/if}
 
           <!-- Progress Bar (when stop condition is active) -->
-          {#if !isCollapsed && stopProgress && instance.isRunning}
+          {#if !isCompact && stopProgress && instance.isRunning}
             <div class="mt-2 pl-5">
               <div class="h-1 bg-muted rounded-full overflow-hidden">
                 <div
@@ -776,7 +778,7 @@
   {:else}
     <!-- Grid Mode Sidebar Content -->
     <div class="flex-1 overflow-y-auto min-h-0">
-      {#if isCollapsed}
+      {#if isCompact}
         <!-- Collapsed: compact aggregate rates -->
         <div class="flex flex-col items-center gap-1 py-3 px-1">
           <span class="text-stat-upload text-[10px] font-bold" title="Total upload rate">
@@ -959,10 +961,10 @@
   <!-- Footer with Network Status and Version -->
   <div class="border-t border-border p-3 space-y-2">
     <!-- Network Status -->
-    <NetworkStatus {isCollapsed} />
+    <NetworkStatus isCollapsed={isCompact} />
 
     <!-- Version + GitHub -->
-    {#if !isCollapsed}
+    {#if !isCompact}
       <a
         href={repository}
         target="_blank"


### PR DESCRIPTION
- Update Sidebar.svelte to use isCompact instead of isCollapsed
- Fix hamburger menu expansion bug at minimum window width
- Ensure correct visibility state for NetworkStatus and version links
- **_Resolves_**: if sidebar is collapsed and windows is resized to the shortest width then clicking on the hambuger menu does not open the expanded sidebar menu, rather it opens the collapsed sidebar.