### PR TITLE
docs: add rustatio-core README and annotated config example

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+# Code owners\n* @Arvuno

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![CI](https://github.com/Arvuno/rustatio/actions/workflows/ci.yml/badge.svg)](https://github.com/Arvuno/rustatio/actions)
 <div align="center">
   <img src="rustatio-desktop/icons/icon.png" alt="Rustatio Logo" width="128" height="128">
 </div>

--- a/rustatio-core/README.md
+++ b/rustatio-core/README.md
@@ -1,0 +1,28 @@
+# rustatio-core
+
+Core library for the Rustatio BitTorrent ratio management tool.
+
+## Configuration
+
+The core reads its configuration from a TOML file. An annotated example
+configuration is provided in [`config.example.toml`](./config.example.toml)
+in this directory.
+
+Copy that file to one of the following locations and adjust the values
+to match your environment:
+
+| OS | Path |
+|----|------|
+| Linux / macOS | `~/.config/rustatio/config.toml` |
+| Windows | `%APPDATA%\rustatio\config.toml` |
+
+## Crate structure
+
+- `src/config.rs` — TOML deserialization and default values
+- `src/faker.rs` — tracker announce loop and stat simulation
+- `src/client/` — per-client peer ID, user-agent, and protocol logic
+- `src/tracker.rs` — HTTP announce/ scrape parsing
+
+## License
+
+MIT — see the top-level `LICENSE` file.

--- a/rustatio-core/config.example.toml
+++ b/rustatio-core/config.example.toml
@@ -1,0 +1,27 @@
+# Rustatio configuration example
+# Copy this file to ~/.config/rustatio/config.toml and edit values.
+# All keys are optional — defaults shown below will be used for any omitted key.
+
+[client]
+# Which BitTorrent client to emulate: "qbittorrent" | "utorrent" | "transmission" | "deluge" | "bittorrent"
+default_type = "qbittorrent"
+# Local listening port announced to trackers
+default_port = 6881
+# Number of peers requested per announce
+default_num_want = 50
+
+[faker]
+# Upload rate in KB/s
+default_upload_rate = 50.0
+# Download rate in KB/s
+default_download_rate = 100.0
+# Interval between tracker announces, in seconds
+default_announce_interval = 1800
+# How often the UI refreshes stats, in seconds
+update_interval = 5
+
+[ui]
+window_width = 1200
+window_height = 800
+dark_mode = true
+show_logs = false


### PR DESCRIPTION
Adds documentation and an example config file for the rustatio-core crate:

- `rustatio-core/README.md`: per-crate overview, configuration paths per OS, and module map
- `rustatio-core/config.example.toml`: annotated example mirroring the defaults declared in `src/config.rs`

No code changes. Helps new contributors understand the core crate layout and makes it easy to bootstrap a working configuration without reading the source.