### PR TITLE
fix(codeowners): replace literal \n with real newlines

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+# Code owners\n* @Arvuno

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
-# Code owners\n* @Arvuno
+# Code owners
+* @Arvuno

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![CI](https://github.com/Arvuno/rustatio/actions/workflows/ci.yml/badge.svg)](https://github.com/Arvuno/rustatio/actions)
 <div align="center">
   <img src="rustatio-desktop/icons/icon.png" alt="Rustatio Logo" width="128" height="128">
 </div>


### PR DESCRIPTION
The current `.github/CODEOWNERS` file contains a literal `\n` sequence on line 1 instead of an actual newline. Fix: rewrite with LF newlines. Detected by CodeRabbit AI.